### PR TITLE
http://timvroom.com/selenium/playground/ nieaktualny link

### DIFF
--- a/automatyzacja/gdzie-trenowac.md
+++ b/automatyzacja/gdzie-trenowac.md
@@ -11,7 +11,7 @@ Poniższe strony można dowolnie wykorzystywać do testów manualnych, przy twor
 * [http://the-internet.herokuapp.com](http://the-internet.herokuapp.com) Herokuapp. The internet.
 * [https://restful-booker.herokuapp.com/](https://restful-booker.herokuapp.com/) API sandbox
 * [https://asta.pgs-soft.com](https://asta.pgs-soft.com) Automated Software Testing Arena
-* [http://timvroom.com/selenium/playground/](http://timvroom.com/selenium/playground/) Piaskownica z wypisanymi zadaniami do zrealizowania
+* [http://timvroom.com/selenium/playground/](http://timvroom.com/selenium/playground/) Piaskownica z wypisanymi zadaniami do zrealizowania > link nieaktualny, witryna nieosiągalna 
 * [http://automationpractice.com](http://automationpractice.com) Wirtualny sklep
 * [http://demoqa.com](http://demoqa.com) Różne funkcje
 * [http://newtours.demoaut.com](http://newtours.demoaut.com) Strona o tematyce turystycznej


### PR DESCRIPTION
http://timvroom.com/selenium/playground/ link nieaktualny, witryna nieosiągalna